### PR TITLE
Adding repo for the website

### DIFF
--- a/resources/github-controller/website.yaml
+++ b/resources/github-controller/website.yaml
@@ -1,11 +1,11 @@
 apiVersion: github.go.hein.dev/v1alpha1
 kind: Repository
 metadata:
-  name: manager
+  name: website
   namespace: default
 spec:
   organization: awsctrl
-  description: Production grade Kubernetes controller for managing AWS Services using CRDs:
+  description: AWS Controller website and documentation:
   homepage: https://awsctrl.io
   settings:
     private: false


### PR DESCRIPTION
This will be where the documentation lives and where the generate getting started guides should reside.

Signed-off-by: Chris Hein <me@chrishein.com>